### PR TITLE
Dockerfile: Upgrade JDK to 1.8 and change the name of container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,31 @@ MAINTAINER Maxime Demolin <akbarova.armia@gmail.com>
 ENV PATH $PATH:node_modules/.bin
 
 
-# Install Java
-RUN apt-get update -q && \
-	apt-get install -qy --no-install-recommends python-dev default-jdk
+ENV LC_ALL C
+ENV DEBIAN_FRONTEND noninteractive
+ENV DEBCONF_NONINTERACTIVE_SEEN true
 
+# Utilities
+RUN apt-get update && apt-get -y install software-properties-common unzip python-dev
+
+# Grab new versions from https://gist.github.com/P7h/9741922
+ENV JAVA_VERSION 8u121-b13/jdk-8u121
+
+# Install Java.
+RUN apt-get update \
+    && apt-get install -y wget openssl ca-certificates \
+    && cd /tmp \
+    && wget -qO jdk8.tar.gz \
+       --header "Cookie: oraclelicense=accept-securebackup-cookie" \
+       http://download.oracle.com/otn-pub/java/jdk/8u111-b14/jdk-8u111-linux-x64.tar.gz \
+    && tar xzf jdk8.tar.gz -C /opt \
+    && mv /opt/jdk* /opt/java \
+    && rm /tmp/jdk8.tar.gz \
+    && update-alternatives --install /usr/bin/java java /opt/java/bin/java 100 \
+    && update-alternatives --install /usr/bin/javac javac /opt/java/bin/javac 100
+
+# Define commonly used JAVA_HOME variable
+ENV JAVA_HOME /opt/java
 
 # Install Android SDK
 
@@ -48,6 +69,8 @@ RUN npm install -g yarn
 
 ## Install react native
 RUN npm install -g react-native-cli@1.0.0
+
+RUN apt-get install -y python-dev
 
 ## Clean up when done
 RUN apt-get clean && \

--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ Usual clone and image install:
 > git clone https://github.com/MaximeD/docker-react-native
 > cd docker-react-native
 
-> docker build -t react-native .
+> docker build -t react-native-develop .
 ```
 
 Next you will need to have the two scripts available in your path. For example you can edit your `.bashrc` and add:
 ```
-export PATH="$HOME/docker-react-native:$PATH"
+export PATH="$(pwd):$PATH"
 ```
 
 ## Create a new react native project

--- a/react-native-container.sh
+++ b/react-native-container.sh
@@ -31,4 +31,4 @@ docker run \
        --net host \
        -e DISPLAY="$DISPLAY" \
        --name $CONTAINER_NAME \
-       react-native /bin/bash
+       react-native-develop /bin/bash


### PR DESCRIPTION
Updating the name of the container with "develop"... That way, it does not collide with the other images.

Unsupported major.minor version 52.0 when rendering in Android Studio
===

* Fixes by using JDK 1.8

